### PR TITLE
fix methods to infer geom and bbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.parquet
 dist/
+.vscode

--- a/stac_table.py
+++ b/stac_table.py
@@ -160,7 +160,7 @@ def generate(
         #         ds.files, storage_options={"filesystem": ds.filesystem}
         #     )
         data = dask_geopandas.read_parquet(uri, storage_options=storage_options)
-        if not data.spatial_partitions:
+        if data.spatial_partitions is None:
             data.calculate_spatial_partitions()
 
     columns = get_columns(ds)

--- a/stac_table.py
+++ b/stac_table.py
@@ -155,12 +155,13 @@ def generate(
         or infer_datetime != InferDatetimeOptions.no
         or proj is True
     ):
+        #     # TODO: this doesn't actually work
+        #     data = dask_geopandas.read_parquet(
+        #         ds.files, storage_options={"filesystem": ds.filesystem}
+        #     )
         data = dask_geopandas.read_parquet(uri, storage_options=storage_options)
-        data.calculate_spatial_partitions()
-    #     # TODO: this doesn't actually work
-    #     data = dask_geopandas.read_parquet(
-    #         ds.files, storage_options={"filesystem": ds.filesystem}
-    #     )
+        if not data.spatial_partitions:
+            data.calculate_spatial_partitions()
 
     columns = get_columns(ds)
     template.properties["table:columns"] = columns


### PR DESCRIPTION
Hi @TomAugspurger, I recently used stac table to create a STAC collection for a parquet dataset. Doing so I made some minor changes to the package. Please have a look if you would like to keep them. 

In the source code I saw some TODO comments about 'maybe converting the geometries to EPSG:4326'. Since my data was in EPSG:3857, I added the reprojection for the geometries that fall directly under the pystac.Item.properties. So the geometries/bbox are now in 4326, whereas the ones under the projection prefix are in the CRS of the source data.  

```python
item.bbox # in 4326
item.geometry # in 4326
item.properties["proj:<geom>"] # in projection of source data
```

For some conditions, the data was being load using `dask_geopandas.read_paquet()`; but at least for my dataset the spatial partitions were not available without computing them first. What do you think about adding a call to calculate_spatial_partitions()?

```python

        # some condition
        data = dask_geopandas.read_parquet(uri, storage_options=storage_options)
        data.calculate_spatial_partitions()
```