### PR TITLE
Use logical types when possible

### DIFF
--- a/stac_table.py
+++ b/stac_table.py
@@ -265,8 +265,12 @@ def get_columns(ds: pyarrow.parquet.ParquetDataset) -> list:
     for field, col in zip(ds.schema, fragment.metadata.schema):
         if field.name == "__null_dask_index__":
             continue
-
-        column = {"name": field.name, "type": col.physical_type.lower()}
+        
+        if col.logical_type.type == "NONE":
+            col_type = col.physical_type
+        else:
+            col_type = col.logical_type.type
+        column = {"name": field.name, "type": col_type.lower()}
         if field.metadata is not None:
             column["metadata"] = field.metadata
         columns.append(column)

--- a/test_stac_table.py
+++ b/test_stac_table.py
@@ -51,11 +51,11 @@ class TestItem:
         )
 
         expected_columns = [
-            {"name": "pop_est", "type": "int64"},
+            {"name": "pop_est", "type": "double"},
             {"name": "continent", "type": "byte_array"},
             {"name": "name", "type": "byte_array"},
             {"name": "iso_a3", "type": "byte_array"},
-            {"name": "gdp_md_est", "type": "double"},
+            {"name": "gdp_md_est", "type": "int64"},
             {"name": "geometry", "type": "byte_array"},
         ]
         assert result.properties["table:columns"] == expected_columns

--- a/test_stac_table.py
+++ b/test_stac_table.py
@@ -52,9 +52,9 @@ class TestItem:
 
         expected_columns = [
             {"name": "pop_est", "type": "double"},
-            {"name": "continent", "type": "byte_array"},
-            {"name": "name", "type": "byte_array"},
-            {"name": "iso_a3", "type": "byte_array"},
+            {"name": "continent", "type": "string"},
+            {"name": "name", "type": "string"},
+            {"name": "iso_a3", "type": "string"},
             {"name": "gdp_md_est", "type": "int64"},
             {"name": "geometry", "type": "byte_array"},
         ]


### PR DESCRIPTION
Hello @TomAugspurger , we have been using stac-table for our project and it has been amazing, thanks for your work!

Using stac-table I have realised that the types returned were based on physical types rather than logical. This is not great to know what the data is because for example both string and bytes show as `byte_array` and both datetimes and integers show as `int64`. 

This PR changes it so that the logical type is used whenever possible, I hope this can be a useful change.

Note: I have also needed to change the types of two columns in the tests to get them to pass before doing any changes to the code, I suspect that the "naturalearth_lowres" dataset in geopandas may have gotten updated at some point. It is also going to be deprecated in the future, so eventually the source data for this test should probably be included in the package.